### PR TITLE
Fix for issue #1

### DIFF
--- a/lib/puret/active_record_extensions.rb
+++ b/lib/puret/active_record_extensions.rb
@@ -42,6 +42,10 @@ module Puret
 
             translation ? translation[attribute] : nil
           end
+
+          define_method "#{attribute}_before_type_cast" do
+            self.send(attribute)
+          end
         end
       end
 

--- a/test/puret_test.rb
+++ b/test/puret_test.rb
@@ -118,4 +118,8 @@ class PuretTest < ActiveSupport::TestCase
     t2 = PostTranslation.new :post => post, :locale => "de"
     assert_not_nil t2.errors[:locale]
   end
+
+  test 'model should provide attribute_before_type_cast' do
+    assert_equal Post.first.title, Post.first.title_before_type_cast
+  end
 end


### PR DESCRIPTION
I've created a fix for #1 by adding the attribute_before_type_cast method to Puret so Rails forms will render out properly.
